### PR TITLE
Add configurable options, prevalues etc

### DIFF
--- a/app/App_Plugins/HtagGridEditor/lang/en-US.xml
+++ b/app/App_Plugins/HtagGridEditor/lang/en-US.xml
@@ -7,5 +7,7 @@
   <area alias="headline">
     <key alias="position">Alignment</key>
     <key alias="size">Heading</key>
+    <key alias="default">Default</key>
+    <key alias="allowed">Allowed</key>
   </area>
 </language>

--- a/app/App_Plugins/HtagGridEditor/package.manifest
+++ b/app/App_Plugins/HtagGridEditor/package.manifest
@@ -5,7 +5,19 @@
       "alias": "htmlHeading",
       "view": "~/App_Plugins/HtagGridEditor/views/headline.editor.html",
       "render": "~/App_Plugins/HtagGridEditor/views/headline.render.cshtml",
-      "icon": "icon-oew-heading"
+      "icon": "icon-oew-heading",
+      "config": {
+        "options": {
+          "size": {
+            "default": "h1",
+            "options": [ "h1", "h2", "h3", "h4", "h5", "h6" ]
+          },
+          "align": {
+            "default": "left",
+            "options": [ "left", "center", "right" ]
+          }
+        }
+      }
     }
   ],
   "propertyEditors": [
@@ -16,11 +28,40 @@
       "group": "Rich Content",
       "editor": {
         "view": "~/App_Plugins/HtagGridEditor/views/headline.editor.html"
+      },
+      "prevalues": {
+        "fields": [
+          {
+            "label": "Options",
+            "description": "Enable/Disable heading sizes/alignments",
+            "key": "options",
+            "view": "~/App_Plugins/HtagGridEditor/views/headline.prevalues.html",
+            "config": {
+              "size": {
+                "options": [ "h1", "h2", "h3", "h4", "h5", "h6" ]
+              },
+              "align": {
+                "options": [ "left", "center", "right" ]
+              }
+            }
+          }
+        ]
+      },
+      "defaultConfig": {
+        "options": {
+          "size": {
+            "default": "h1"
+          },
+          "align": {
+            "default": "left"
+          }
+        }
       }
     }
   ],
   "javascript": [
-    "~/App_Plugins/HtagGridEditor/scripts/headline.controller.js"
+    "~/App_Plugins/HtagGridEditor/scripts/headline.controller.js",
+    "~/App_Plugins/HtagGridEditor/scripts/prevalue.controller.js"
   ],
   "css": [
     "~/App_Plugins/HtagGridEditor/css/headline.icons.css",

--- a/app/App_Plugins/HtagGridEditor/scripts/headline.controller.js
+++ b/app/App_Plugins/HtagGridEditor/scripts/headline.controller.js
@@ -12,6 +12,14 @@
         config = $scope.control.editor.config;
     }
 
+    function setValue(align, size, text) {
+        $scope.control.value = {
+            "textAlign": align ? align : config.options.align.default,
+            "hTag": size ? size : config.options.size.default,
+            "text": text
+        };
+    }
+
     if ($scope.control.value !== null) {
         //Handles conversion between editors created in version 1.0.1 to newer
         if (!angular.isObject($scope.control.value)) {
@@ -19,21 +27,10 @@
             var oldTag = $scope.control.hTag;
             var oldAlign = $scope.control.textAlign;
 
-            $scope.control.value = {
-                "textAlign": oldAlign,
-                "hTag": oldTag,
-                "text": oldText
-            };
+            setValue(oldAlign, oldTag, oldText);
         }
     } else {
-        var defaultAlign = config.options.align.default;
-        var defaultSize = config.options.size.default;
-
-        $scope.control.value = {
-            textAlign: defaultAlign ? defaultAlign : "left",
-            hTag: defaultSize ? defaultSize : "h1",
-            text: ''
-        }
+        setValue();
     }
 
     $scope.sizeOptions = config.options && config.options.size && config.options.size.options ? config.options.size.options : "h1,h2,h3,h4,h5,h6".split(",");

--- a/app/App_Plugins/HtagGridEditor/scripts/headline.controller.js
+++ b/app/App_Plugins/HtagGridEditor/scripts/headline.controller.js
@@ -1,18 +1,15 @@
 ﻿angular.module("umbraco").controller("Our.Umbraco.HtagEditor.Controller", function ($scope) {
 
+    var config = {};
+
     if(!$scope.control) {
-        // property editor usage, spoof grid control
+        // property editor usage
         $scope.control = $scope.model
-
-        if ($scope.model.value === null || $scope.model.value === "") {
-
-            // set initial defaults
-            $scope.model.value = {
-                textAlign: 'left',
-                    hTag: 'h1',
-                    text: ''
-            }
-        }
+        config = $scope.model.config;
+    }
+    else {
+        // grid usage
+        config = $scope.control.editor.config;
     }
 
     if ($scope.control.value !== null) {
@@ -29,11 +26,18 @@
             };
         }
     } else {
+        var defaultAlign = config.options.align.default;
+        var defaultSize = config.options.size.default;
+
         $scope.control.value = {
-            "textAlign": "left",
-            "hTag": "h1"
-        };
+            textAlign: defaultAlign ? defaultAlign : "left",
+            hTag: defaultSize ? defaultSize : "h1",
+            text: ''
+        }
     }
+
+    $scope.sizeOptions = config.options && config.options.size && config.options.size.options ? config.options.size.options : "h1,h2,h3,h4,h5,h6".split(",");
+    $scope.alignOptions = config.options && config.options.align && config.options.align.options ? config.options.align.options : "left,center,right".split(",");
 
     $scope.setPosition = function (pos) {
         $scope.control.value.textAlign = pos;

--- a/app/App_Plugins/HtagGridEditor/scripts/prevalue.controller.js
+++ b/app/App_Plugins/HtagGridEditor/scripts/prevalue.controller.js
@@ -1,7 +1,10 @@
 ﻿angular.module("umbraco").controller("Our.Umbraco.HtagEditor.PreValueController", function ($scope, $http, $routeParams, assetsService, contentResource, notificationsService) {
 
-    $scope.sizeOptions =  $scope.model.config && $scope.model.config.options && $scope.model.config.options.size && $scope.model.config.options.size.options ? config.options.size.options : "h1,h2,h3,h4,h5,h6".split(",");
-    $scope.alignOptions = $scope.model.config && $scope.model.config.options && $scope.model.config.options.align && $scope.model.config.options.align.options ? config.options.align.options : "left,center,right".split(",");
+    var defaultSizes = ["h1","h2","h3","h4","h5","h6"];
+    var defaultAlign = ["left","center","right"];
+
+    $scope.sizeOptions =  $scope.model.config && $scope.model.config.options && $scope.model.config.options.size && $scope.model.config.options.size.options ? config.options.size.options : defaultSizes;
+    $scope.alignOptions = $scope.model.config && $scope.model.config.options && $scope.model.config.options.align && $scope.model.config.options.align.options ? config.options.align.options : defaultAlign;
 
     if (!$scope.model.value.size.options)
         $scope.model.value.size.options = $scope.sizeOptions.slice(0);
@@ -11,6 +14,7 @@
 
     $scope.toggleAlign = function(align){
         toggleOption($scope.model.value.align.options, align, $scope.model.value.align.default);
+        sort($scope.model.value.align.options, defaultAlign);
     }
 
     $scope.defaultAlign = function(align){
@@ -29,6 +33,7 @@
 
     $scope.toggleSize = function(size){
         toggleOption($scope.model.value.size.options, size, $scope.model.value.size.default);
+        $scope.model.value.size.options.sort();
     }
 
     function isSelected(values, value) {
@@ -44,5 +49,11 @@
         else {
             selected.push(valueToToggle);
         }
+    }
+
+    function sort(arrayToSort, referenceArray) {
+        arrayToSort.sort(function(a, b) {
+            return referenceArray.indexOf(a) - referenceArray.indexOf(b);
+        });
     }
 });

--- a/app/App_Plugins/HtagGridEditor/scripts/prevalue.controller.js
+++ b/app/App_Plugins/HtagGridEditor/scripts/prevalue.controller.js
@@ -1,0 +1,48 @@
+﻿angular.module("umbraco").controller("Our.Umbraco.HtagEditor.PreValueController", function ($scope, $http, $routeParams, assetsService, contentResource, notificationsService) {
+
+    $scope.sizeOptions =  $scope.model.config && $scope.model.config.options && $scope.model.config.options.size && $scope.model.config.options.size.options ? config.options.size.options : "h1,h2,h3,h4,h5,h6".split(",");
+    $scope.alignOptions = $scope.model.config && $scope.model.config.options && $scope.model.config.options.align && $scope.model.config.options.align.options ? config.options.align.options : "left,center,right".split(",");
+
+    if (!$scope.model.value.size.options)
+        $scope.model.value.size.options = $scope.sizeOptions.slice(0);
+
+    if (!$scope.model.value.align.options)
+        $scope.model.value.align.options = $scope.alignOptions.slice(0);
+
+    $scope.toggleAlign = function(align){
+        toggleOption($scope.model.value.align.options, align, $scope.model.value.align.default);
+    }
+
+    $scope.defaultAlign = function(align){
+        var item = $scope.model.value.align;
+        item.default = align;
+        if(!isSelected(item.options, align))
+            toggleOption(item.options, align);
+    }
+
+    $scope.defaultSize = function(size){
+        var item = $scope.model.value.size;
+        item.default = size;
+        if(!isSelected(item.options, size))
+            toggleOption(item.options, size);
+    }
+
+    $scope.toggleSize = function(size){
+        toggleOption($scope.model.value.size.options, size, $scope.model.value.size.default);
+    }
+
+    function isSelected(values, value) {
+        return values.indexOf(value) !== -1;
+    }
+
+    function toggleOption(selected, valueToToggle, currentDefault) {
+        var index = selected.indexOf(valueToToggle);
+        if (index !== -1) {
+            if (valueToToggle !== currentDefault)
+                selected.splice(index, 1); 
+        }
+        else {
+            selected.push(valueToToggle);
+        }
+    }
+});

--- a/app/App_Plugins/HtagGridEditor/views/headline.editor.html
+++ b/app/App_Plugins/HtagGridEditor/views/headline.editor.html
@@ -1,6 +1,6 @@
 ﻿<div ng-controller="Our.Umbraco.HtagEditor.Controller">
-    <div class="headline clearfix">
-        <textarea rows="1" class="textstring input-block-level text-{{control.value.textAlign}} {{control.value.hTag}}" localize="placeholder" placeholder="grid_placeholderWriteHere" ng-model="control.value.text"></textarea>
+    <div class="headline clearfix {{ control.config.css }}">
+        <textarea umb-auto-resize rows="1" class="textstring input-block-level text-{{control.value.textAlign}} {{control.value.hTag}}" localize="placeholder" placeholder="grid_placeholderWriteHere" ng-model="control.value.text"></textarea>
 
         <div class="toolbar-wrapper">
             <span><localize key="headline_position">Position</localize></span>

--- a/app/App_Plugins/HtagGridEditor/views/headline.editor.html
+++ b/app/App_Plugins/HtagGridEditor/views/headline.editor.html
@@ -5,19 +5,9 @@
         <div class="toolbar-wrapper">
             <span><localize key="headline_position">Position</localize></span>
             <ul class="toolbar">
-                <li ng-click="setPosition('left')" ng-class="{'active': control.value.textAlign=='left'}">
+                <li ng-repeat="align in alignOptions" ng-click="setPosition(align)" ng-class="{'active': control.value.textAlign === align}">
                     <span class="icon-wrap">
-                        <i class="icon-oew-align-left"></i>
-                    </span>
-                </li>
-                <li ng-click="setPosition('center')" ng-class="{'active': control.value.textAlign=='center'}">
-                    <span class="icon-wrap">
-                        <i class="icon-oew-align-center"></i>
-                    </span>
-                </li>
-                <li ng-click="setPosition('right')" ng-class="{'active': control.value.textAlign=='right'}">
-                    <span class="icon-wrap">
-                        <i class="icon-oew-align-right"></i>
+                        <i class="icon-oew-align-{{align}}"></i>
                     </span>
                 </li>
             </ul>
@@ -26,40 +16,10 @@
         <div class="toolbar-wrapper">
             <span><localize key="headline_size">Size</localize></span>
             <ul class="toolbar">
-                <li ng-click="setSize('h1')" ng-class="{'active': control.value.hTag=='h1'}">
+                <li ng-repeat="size in sizeOptions" ng-click="setSize(size)" ng-class="{'active': control.value.hTag === size}">
                     <span class="icon-wrap">
                         <i class="icon-oew-heading"></i>
-                        <span class="icon-layers-text">1</span>
-                    </span>
-                </li>
-                <li ng-click="setSize('h2')" ng-class="{'active': control.value.hTag=='h2'}">
-                    <span class="icon-wrap">
-                        <i class="icon-oew-heading"></i>
-                        <span class="icon-layers-text">2</span>
-                    </span>
-                </li>
-                <li ng-click="setSize('h3')" ng-class="{'active': control.value.hTag=='h3'}">
-                    <span class="icon-wrap">
-                        <i class="icon-oew-heading"></i>
-                        <span class="icon-layers-text">3</span>
-                    </span>
-                </li>
-                <li ng-click="setSize('h4')" ng-class="{'active': control.value.hTag=='h4'}">
-                    <span class="icon-wrap">
-                        <i class="icon-oew-heading"></i>
-                        <span class="icon-layers-text">4</span>
-                    </span>
-                </li>
-                <li ng-click="setSize('h5')" ng-class="{'active': control.value.hTag=='h5'}">
-                    <span class="icon-wrap">
-                        <i class="icon-oew-heading"></i>
-                        <span class="icon-layers-text">5</span>
-                    </span>
-                </li>
-                <li ng-click="setSize('h6')" ng-class="{'active': control.value.hTag=='h6'}">
-                    <span class="icon-wrap">
-                        <i class="icon-oew-heading"></i>
-                        <span class="icon-layers-text">6</span>
+                        <span class="icon-layers-text">{{ size[size.length - 1] }}</span>
                     </span>
                 </li>
             </ul>

--- a/app/App_Plugins/HtagGridEditor/views/headline.prevalues.html
+++ b/app/App_Plugins/HtagGridEditor/views/headline.prevalues.html
@@ -1,0 +1,51 @@
+﻿<div ng-controller="Our.Umbraco.HtagEditor.PreValueController">
+   
+    <div class="headline">
+        <div class="toolbar-wrapper">
+            <span><localize key="headline_allowed">Allowed</localize></span>
+            <ul class="toolbar">
+                <li ng-repeat="align in alignOptions" ng-click="toggleAlign(align)" ng-class="{'active': model.value.align.options.indexOf(align) !== -1}">
+                    <span class="icon-wrap">
+                        <i class="icon-oew-align-{{align}}"></i>
+                    </span>
+                </li>
+            </ul>
+        </div>
+
+        <div class="toolbar-wrapper">
+            <span>&nbsp;</span>
+            <ul class="toolbar">
+                <li ng-repeat="size in sizeOptions" ng-click="toggleSize(size)" ng-class="{'active': model.value.size.options.indexOf(size) !== -1}">
+                    <span class="icon-wrap">
+                        <i class="icon-oew-heading"></i>
+                        <span class="icon-layers-text">{{ size[size.length - 1] }}</span>
+                    </span>
+                </li>
+            </ul>
+        </div>
+        
+        <div class="toolbar-wrapper" style="clear:both;">
+            <span><localize key="headline_default">Default</localize></span>
+            <ul class="toolbar">
+                <li ng-repeat="align in alignOptions" ng-click="defaultAlign(align)" ng-class="{'active': model.value.align.default === align}">
+                    <span class="icon-wrap">
+                        <i class="icon-oew-align-{{align}}"></i>
+                    </span>
+                </li>
+            </ul>
+        </div>
+
+        <div class="toolbar-wrapper">
+            <span>&nbsp;</span>
+            <ul class="toolbar">
+                <li ng-repeat="size in sizeOptions" ng-click="defaultSize(size)" ng-class="{'active': model.value.size.default === size}">
+                    <span class="icon-wrap">
+                        <i class="icon-oew-heading"></i>
+                        <span class="icon-layers-text">{{ size[size.length - 1] }}</span>
+                    </span>
+                </li>
+            </ul>
+        </div>
+    </div>
+
+</div>


### PR DESCRIPTION
Added configurable options. Allows disabling of each size/alignment, and to define a default, both for property editor use via prevalues:

![image](https://user-images.githubusercontent.com/629719/75241589-45857b80-57be-11ea-9a47-06e302544e40.png)

![image](https://user-images.githubusercontent.com/629719/75241413-f0e20080-57bd-11ea-87a1-3acf05121c83.png)


And as a grid editor via config:

![image](https://user-images.githubusercontent.com/629719/75241377-e0318a80-57bd-11ea-9f6d-13b6e2b0d074.png)

![image](https://user-images.githubusercontent.com/629719/75241336-cee87e00-57bd-11ea-9442-b2b2c35057dd.png)

Also added:

- umb-auto-resize to the text area, to auto adjust height, 
- a config option to add a class onto the editor to ease additional custom styling

